### PR TITLE
Change mkdir method (makes parents now)

### DIFF
--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -96,7 +96,7 @@ def install_system_packages(names, update=False):
 def mkdir(path, mode, uid, gid):
     """Create a directory."""
     if not os.path.exists(path):
-        os.mkdir(path, mode)
+        os.makedirs(path, mode)
     else:
         os.chmod(path, mode)
     os.chown(path, uid, gid)


### PR DESCRIPTION
The mkdir function was using os.mkdir, which wasn't creating parent directories, and the script was therefore failing. Rather than explicitly creating each parent, it seems a fair use to change the os.mkdir function to os.makedirs (which does automatically create parents). This allows the script to finish successfully.