### PR TITLE
update SSL logic to accomodate pregenerated certificates

### DIFF
--- a/modoboa_installer/ssl.py
+++ b/modoboa_installer/ssl.py
@@ -11,16 +11,19 @@ class CertificateBackend(object):
     def __init__(self, config):
         """Set path to certificates."""
         self.config = config
-        for base_dir in ["/etc/pki/tls", "/etc/ssl"]:
-            if os.path.exists(base_dir):
-                self.config.set(
-                    "general", "tls_key_file",
-                    "{}/private/%(hostname)s.key".format(base_dir))
-                self.config.set(
-                    "general", "tls_cert_file",
-                    "{}/certs/%(hostname)s.cert".format(base_dir))
-                return
-        raise RuntimeError("Cannot find a directory to store certificate")
+        if not config.has_option("general", "tls_key_file"):
+            for base_dir in ["/etc/pki/tls", "/etc/ssl"]:
+                if os.path.exists(base_dir):
+                    self.config.set(
+                        "general", "tls_key_file",
+                        "{}/private/%(hostname)s.key".format(base_dir))
+                    self.config.set(
+                        "general", "tls_cert_file",
+                        "{}/certs/%(hostname)s.cert".format(base_dir))
+                    return
+            raise RuntimeError("Cannot find a directory to store certificate")
+        else:
+            return
 
 
 class SelfSignedCertificate(CertificateBackend):


### PR DESCRIPTION
The @ecobytes instance showed a misbehaviour concerning TLS certificates which had been set in instance.cfg.
Ultimately 89cdc314ea9ad93d7951d1800e525f85ec47eaac#diff-c226f84131b50059e044a64c41fe782c added a logic which would not account for preconfigured TLS certificates anymore.
This commit introduces a small change to revive usage of third-party certificates without overwriting their configuration options.