### PR TITLE
possible fix for #63

### DIFF
--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -45,7 +45,7 @@ class Modoboa(base.Installer):
     def _setup_venv(self):
         """Prepare a dedicated virtuelenv."""
         python.setup_virtualenv(self.venv_path, sudo_user=self.user)
-        packages = ["modoboa", "rrdtool"]
+        packages = ["modoboa", "rrdtool==0.1.6"]
         if self.dbengine == "postgres":
             packages.append("psycopg2")
         else:

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -76,9 +76,12 @@ def dist_name():
 def mkdir(path, mode, uid, gid):
     """Create a directory."""
     if not os.path.exists(path):
-        os.mkdir(path, mode)
-    else:
-        os.chmod(path, mode)
+        try: 
+            os.mkdir(path)
+        except OSError:
+            os.mkdirs(path)
+        pass
+    os.chmod(path, mode)
     os.chown(path, uid, gid)
 
 

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -79,7 +79,7 @@ def mkdir(path, mode, uid, gid):
         try: 
             os.mkdir(path)
         except OSError:
-            os.mkdirs(path)
+            os.makedirs(path)
         pass
     os.chmod(path, mode)
     os.chown(path, uid, gid)


### PR DESCRIPTION
I used this fork of the script to install onto a clean Debian 8 install and was successful. However, when I deleted `/srv/modoboa`, future installations failed because the `/srv/modoboa/instance` directory was still owned by root. I tried setting the owner to modoboa, but I was unsuccessful. Hopefully, that is a small issue.