### PR TITLE
Community fork : assure file permissions more strictly

### DIFF
--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -77,7 +77,7 @@ def mkdir(path, mode, uid, gid):
     """Create a directory."""
     dir = os.path.dirname(path)
     if not os.path.exists(dir):
-        os.makedirs(dir)
+        os.makedirs(dir, mode)
     else:
         os.chmod(dir, mode)
     os.chown(dir, uid, gid)

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -75,11 +75,12 @@ def dist_name():
 
 def mkdir(path, mode, uid, gid):
     """Create a directory."""
-    if not os.path.exists(path):
-        os.mkdir(path, mode)
+    dir = os.path.dirname(path)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
     else:
-        os.chmod(path, mode)
-    os.chown(path, uid, gid)
+        os.chmod(dir, mode)
+    os.chown(dir, uid, gid)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Currently the installer assumes root priviledge.

User @senner introduced some commits into their fork to assure file permissions more strictly.

Would these commits solve issues other users see elsewhere or do these refer to a specific local environment?