### PR TITLE
Make OpenSSL use less computing power, closes #87

### DIFF
--- a/modoboa_installer/scripts/nginx.py
+++ b/modoboa_installer/scripts/nginx.py
@@ -55,5 +55,5 @@ class Nginx(base.Installer):
         system.add_user_to_group(user, group)
 
         if not os.path.exists("{}/dhparam.pem".format(self.config_dir)):
-            cmd = "openssl dhparam -out dhparam.pem 4096"
+            cmd = "openssl dhparam -dsaparam -out dhparam.pem 4096"
             utils.exec_cmd(cmd, cwd=self.config_dir)

--- a/modoboa_installer/scripts/postfix.py
+++ b/modoboa_installer/scripts/postfix.py
@@ -85,5 +85,5 @@ class Postfix(base.Installer):
 
         # Generate EDH parameters
         if not os.path.exists("{}/dh2048.pem".format(self.config_dir)):
-            cmd = "openssl dhparam -out dh2048.pem 2048"
+            cmd = "openssl dhparam -dsaparam -out dh2048.pem 2048"
             utils.exec_cmd(cmd, cwd=self.config_dir)


### PR DESCRIPTION
http://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours suggests to add the `-dsaparam` to the OpenSSL commandline for unarbitrarily long running Diffie-Hellman parameters generation.