### PR TITLE
Changed string.letters to string.asciletters in utils

### DIFF
--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -87,7 +87,7 @@ def make_password(length=16):
     """Create a random password."""
     return "".join(
         random.SystemRandom().choice(
-            string.letters + string.digits) for _ in range(length))
+            string.ascii_letters + string.digits) for _ in range(length))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
string.asciletters is not locale-dependent but exists both in python2 and 3
so that avoids the script to break in python3 at a minor expense in my opinion

Description of the issue/feature this PR addresses:

Current behavior before PR: 
```
    string.letters + string.digits) for _ in range(length))
AttributeError: module 'string' has no attribute 'letters'
```

Desired behavior after PR is merged: script run fine in both python 2 and 3
