### PR TITLE
Added support for modoboa version selection.

### DIFF
--- a/modoboa_installer/compatibility_matrix.py
+++ b/modoboa_installer/compatibility_matrix.py
@@ -1,6 +1,9 @@
 """Modoboa compatibility matrix."""
 
 COMPATIBILITY_MATRIX = {
+    # Example:
+    #
+    # "1.8.1": {}
 }
 
 EXTENSIONS_AVAILABILITY = {

--- a/modoboa_installer/compatibility_matrix.py
+++ b/modoboa_installer/compatibility_matrix.py
@@ -1,0 +1,8 @@
+"""Modoboa compatibility matrix."""
+
+COMPATIBILITY_MATRIX = {
+}
+
+EXTENSIONS_AVAILABILITY = {
+    "modoboa-contacts": "1.7.4",
+}

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -171,6 +171,8 @@ def has_colours(stream):
     except:
         # guess false in case of error
         return False
+
+
 has_colours = has_colours(sys.stdout)
 
 
@@ -179,3 +181,30 @@ def printcolor(message, color):
     if has_colours:
         message = "\x1b[1;{}m{}\x1b[0m".format(30 + color, message)
     print(message)
+
+
+def convert_version_to_int(version):
+    """Convert a version string to an integer."""
+    number_bits = (8, 8, 16)
+
+    numbers = [int(number_string) for number_string in version.split(".")]
+    if len(numbers) > len(number_bits):
+        raise NotImplementedError(
+            "Versions with more than {0} decimal places are not supported"
+            .format(len(number_bits) - 1)
+        )
+    # add 0s for missing numbers
+    numbers.extend([0] * (len(number_bits) - len(numbers)))
+    # convert to single int and return
+    number = 0
+    total_bits = 0
+    for num, bits in reversed(list(zip(numbers, number_bits))):
+        max_num = (bits + 1) - 1
+        if num >= 1 << max_num:
+            raise ValueError(
+                "Number {0} cannot be stored with only {1} bits. Max is {2}"
+                .format(num, bits, max_num)
+            )
+        number += num << total_bits
+        total_bits += bits
+    return number

--- a/run.py
+++ b/run.py
@@ -8,10 +8,11 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-from modoboa_installer import scripts
-from modoboa_installer import utils
+from modoboa_installer import compatibility_matrix
 from modoboa_installer import package
+from modoboa_installer import scripts
 from modoboa_installer import ssl
+from modoboa_installer import utils
 
 
 def main():
@@ -23,6 +24,10 @@ def main():
                         help="Force installation")
     parser.add_argument("--configfile", default="installer.cfg",
                         help="Configuration file to use")
+    parser.add_argument(
+        "--version", default="latest",
+        choices=["latest"] + compatibility_matrix.COMPATIBILITY_MATRIX.keys(),
+        help="Modoboa version to install")
     parser.add_argument(
         "--stop-after-configfile-check", action="store_true", default=False,
         help="Check configuration, generate it if needed and exit")
@@ -42,6 +47,7 @@ def main():
     if not config.has_section("general"):
         config.add_section("general")
     config.set("general", "domain", args.domain)
+    config.set("modoboa", "version", args.version)
     utils.printcolor(
         "Your mail server will be installed with the following components:",
         utils.BLUE)
@@ -79,6 +85,7 @@ def main():
         "Congratulations! You can enjoy Modoboa at https://{} (admin:password)"
         .format(config.get("general", "hostname")),
         utils.GREEN)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
A new option to choose a different Modoboa version to install. Due to an issue with the deploy command (see https://github.com/modoboa/modoboa/issues/1177), only versions >= 1.8.1 will be concerned.

see #138