### PR TITLE
Possible fix for #147 - automx.py

### DIFF
--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -56,7 +56,7 @@ class Automx(base.Installer):
         python.setup_virtualenv(self.venv_path, sudo_user=self.user)
         packages = [
             "future", "lxml", "ipaddress", "sqlalchemy", "python-memcached",
-            "python-dateutil", "configparser"
+            "python-dateutil", "configparser", "psycopg2"
         ]
         python.install_packages(packages, self.venv_path, sudo_user=self.user)
         target = "{}/master.zip".format(self.home_dir)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 Package psycopg2 was not in the list of dependencies (packages to be installed with automx script).

Current behavior before PR:
 Generated error "ERROR: SQL: No module named psycopg2" in automx_instance.log

Desired behavior after PR is merged:
 No error

#147 