### PR TITLE
Fix typo in automx.conf.tpl

### DIFF
--- a/modoboa_installer/scripts/files/automx/automx.conf.tpl
+++ b/modoboa_installer/scripts/files/automx/automx.conf.tpl
@@ -10,7 +10,7 @@ rate_limit_exception_networks = 127.0.0.0/8, ::1/128
 
 [global]
 backend = sql
-actions = settings
+action = settings
 account_type = email
 host = %sql_dsn
 query = %sql_query


### PR DESCRIPTION
Fix typo which breaks autodiscover
See issue #154

Description of the issue/feature this PR addresses:
automx.conf.tpl

Current behavior before PR:
Typo in default installed config breaks autodiscover

Desired behavior after PR is merged:
Autodiscover setup works without searching for bugs in default config