### PR TITLE
Fix the auth_mechanisms setting in dovecot/10-auth.conf. Closes #175

### DIFF
--- a/modoboa_installer/scripts/files/dovecot/conf.d/10-auth.conf
+++ b/modoboa_installer/scripts/files/dovecot/conf.d/10-auth.conf
@@ -96,7 +96,7 @@ auth_master_user_separator = *
 #   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp skey
 #   gss-spnego
 # NOTE: See also disable_plaintext_auth setting.
-auth_mechanisms = plain
+auth_mechanisms = plain login cram-md5
 
 ##
 ## Password and user databases


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix the auth_mechanisms setting in dovecot/10-auth.conf. Closes #175

Current behavior before PR:
Outlook on the Mac cannot send mail

Desired behavior after PR is merged:
On new installs, Outlook on the Mac can send mail