### PR TITLE
opendkim: add LogResults = Yes

### DIFF
--- a/modoboa_installer/scripts/files/opendkim/opendkim.conf.tpl
+++ b/modoboa_installer/scripts/files/opendkim/opendkim.conf.tpl
@@ -4,8 +4,10 @@
 
 # Log to syslog
 Syslog			yes
-LogWhy			Yes
 SyslogSuccess   	Yes
+LogWhy			Yes
+LogResults  Yes
+
 # Required to use local socket with MTAs that access the socket as a non-
 # privileged user (e.g. Postfix)
 UMask			007


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If logging is enabled (see Syslog below), requests that the results of evaluation of all signatures that were at least partly intact (i.e., the "d=", "s=", and "b=" tags could be extracted).

Current behavior before PR:

Not revelent

Desired behavior after PR is merged:

Not revelent