### PR TITLE
Make sure opendkim is started *after* postgres.

### DIFF
--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -91,3 +91,9 @@ class Opendkim(base.Installer):
             "SOCKET=inet:12345\@localhost/"
         )
         utils.exec_cmd("perl -pi -e '{}' /etc/default/opendkim".format(pattern))
+
+        # Make sure opendkim is started after postgres
+        pattern = (
+            "s/^After=(.*)$/After=\1 postgresql.service/"
+        )
+        utils.exec_cmd("perl -pi -e '{}' /lib/systemd/system/opendkim.service".format(pattern))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Makes sure that opendkim is started after postgresql, as it depends on it.

Current behavior before PR:

OpenDKIM might be started before postgres, which makes it fail as it's dependent on postgres.

Desired behavior after PR is merged:

Services started in the correct order.