### PR TITLE
Update /etc/default/opendkim on Debian-based system post installation.

### DIFF
--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -78,16 +78,16 @@ class Opendkim(base.Installer):
             dbname, "dkim", self.app_config["dbuser"], "SELECT")
 
     def post_run(self):
-        """Addtional tasks."""
+        """Additional tasks."""
         if package.backend.FORMAT != "deb":
             return
-        pattern = (
-            "s/^SOCKET=local:\$RUNDIR\/opendkim\.sock/"
-            "#SOCKET=local:\$RUNDIR\/opendkim\.sock/"
-        )
-        utils.exec_cmd("perl -pi -e '{}' /etc/default/opendkim".format(pattern))
-        pattern = (
-            "s/^#SOCKET=inet:12345\@localhost$/"
-            "SOCKET=inet:12345\@localhost/"
-        )
-        utils.exec_cmd("perl -pi -e '{}' /etc/default/opendkim".format(pattern))
+        params_file = "/etc/default/opendkim"
+        pattern = r"s/^(SOCKET=.*)/#\1/"
+        utils.exec_cmd(
+            "perl -pi -e '{}' {}".format(pattern, params_file))
+        with open(params_file, "a") as f:
+          f.write('\n'.join([
+              "",
+              'SOCKET="inet:12345@localhost"',
+          ]))
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixes issue #207 

Current behavior before PR:

On Ubuntu 16.04, the file `/etc/default/opendkim` is not edited, and specifies an incorrect socket for OpenDKIM to listen to. As a result, Postfix is unable to connect to OpenDKIM.

Desired behavior after PR is merged:

The correct port 12345 is specified in `/etc/default/opendkim`.