### PR TITLE
Fixed recipient restrictions

### DIFF
--- a/modoboa_installer/scripts/files/postfix/master.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/master.cf.tpl
@@ -25,7 +25,6 @@ submission inet n       -       -       -       -       smtpd
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
   -o smtpd_helo_restrictions=
   -o smtpd_sender_restrictions=reject_sender_login_mismatch
-  -o smtpd_recipient_restrictions=
   -o milter_macro_daemon_name=ORIGINATING
 %{amavis_enabled}  -o smtpd_proxy_filter=inet:[127.0.0.1]:10026
 #smtps     inet  n       -       -       -       -       smtpd


### PR DESCRIPTION
Fixes #237 - the ```-o smtpd_recipient_restrictions=``` overrides the config in ```main.cf``` and causes Postfix to reject mail from some clients

Current behavior before PR:
Postfix rejects mail from some mail clients (like Windows Mail and Thunderbird), while simultaneously complaining that there is no rejection of recipients.

Desired behavior after PR is merged:
The mail clients can send email
