### PR TITLE
Make sure OpenDKIM is started after PostgreSQL/MySQL

### DIFF
--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -90,3 +90,10 @@ class Opendkim(base.Installer):
                 "",
                 'SOCKET="inet:12345@localhost"',
             ]))
+        # Make sure opendkim is started after postgresql and mysql, respectively
+        dbservice = "postgresql.service" if self.dbengine == "postgres" else "mysql.service"
+        pattern = (
+            "s/^After=(.*)$/After=$1 {}/".format(dbservice)
+        )
+        utils.exec_cmd(
+            "perl -pi -e '{}' /lib/systemd/system/opendkim.service".format(pattern))

--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -91,9 +91,13 @@ class Opendkim(base.Installer):
                 'SOCKET="inet:12345@localhost"',
             ]))
         # Make sure opendkim is started after postgresql and mysql, respectively
-        dbservice = "postgresql.service" if self.dbengine == "postgres" else "mysql.service"
+        if self.dbengine == "postgres":
+          dbservice = "postgresql.service"
+        elif "centos" in utils.dist_name():
+          dbservice = "mysqld.service"
+        else:
+          dbservice = "mysql.service"
         pattern = (
-            "s/^After=(.*)$/After=$1 {}/".format(dbservice)
-        )
+            "s/^After=(.*)$/After=$1 {}/".format(dbservice))
         utils.exec_cmd(
             "perl -pi -e '{}' /lib/systemd/system/opendkim.service".format(pattern))


### PR DESCRIPTION
This is an extension of @oscarcarlsson's [PR 217](https://github.com/modoboa/modoboa-installer/pull/217) which adds a differentiation between PostgreSQL and MySQL. Furthermore, it fixes a bug in the regular expression (`\1` -> `$1`).

Be aware that it may be necessary to use `mysqld.service` on RPM platforms ([source](https://dev.mysql.com/doc/mysql-linuxunix-excerpt/5.7/en/using-systemd.html)). Please decide if this particular case should be supported, too.