### PR TITLE
Pr dkim set db prio for deb & rpm, for mysql & postgres

### DIFF
--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -90,3 +90,10 @@ class Opendkim(base.Installer):
                 "",
                 'SOCKET="inet:12345@localhost"',
             ]))
+        # Make sure opendkim is started after postgresql and mysql, respectively
+        dbservice = "postgresql.service" if self.dbengine == "postgres" else "mysql.service"
+        pattern = (
+            "s/^After=(.*)$/After=$1 {}/".format(dbservice)
+        )
+        utils.exec_cmd(
+            "perl -pi -e '{}' /lib/systemd/system/opendkim.service".format(pattern))

--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -91,9 +91,13 @@ class Opendkim(base.Installer):
                 'SOCKET="inet:12345@localhost"',
             ]))
         # Make sure opendkim is started after postgresql and mysql, respectively
-        dbservice = "postgresql.service" if self.dbengine == "postgres" else "mysql.service"
+        if self.dbengine == "postgres":
+          dbservice = "postgresql.service"
+        elif "centos" in utils.dist_name():
+          dbservice = "mysqld.service"
+        else:
+          dbservice = "mysql.service"
         pattern = (
-            "s/^After=(.*)$/After=$1 {}/".format(dbservice)
-        )
+            "s/^After=(.*)$/After=$1 {}/".format(dbservice))
         utils.exec_cmd(
             "perl -pi -e '{}' /lib/systemd/system/opendkim.service".format(pattern))

--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -78,10 +78,16 @@ class Opendkim(base.Installer):
             dbname, "dkim", self.app_config["dbuser"], "SELECT")
 
     def post_run(self):
-        """Additional tasks."""
-        if package.backend.FORMAT != "deb":
-            return
-        params_file = "/etc/default/opendkim"
+        """Additional tasks.
+        Check linux distribution (package deb, rpm), to adapt
+        to config file location and syntax.
+        - update opendkim isocket port config
+        - make sure opendkim starts after db service started
+        """
+        if package.backend.FORMAT == "deb":
+            params_file = "/etc/default/opendkim"
+        else:
+            params_file = "/etc/opendkim.conf"
         pattern = r"s/^(SOCKET=.*)/#\1/"
         utils.exec_cmd(
             "perl -pi -e '{}' {}".format(pattern, params_file))
@@ -90,13 +96,14 @@ class Opendkim(base.Installer):
                 "",
                 'SOCKET="inet:12345@localhost"',
             ]))
-        # Make sure opendkim is started after postgresql and mysql, respectively
-        if self.dbengine == "postgres":
-          dbservice = "postgresql.service"
-        elif "centos" in utils.dist_name():
-          dbservice = "mysqld.service"
+
+        """ Make sure opendkim is started after postgresql and mysql, respectively. """
+        if (self.dbengine != "postgres" and package.backend.FORMAT == "deb"):
+            dbservice = "mysql.service"
+        elif (self.dbengine != "postgres" and package.backend.FORMAT != "deb"):
+            dbservice = "mysqld.service"
         else:
-          dbservice = "mysql.service"
+            dbservice = "postgresql.service"
         pattern = (
             "s/^After=(.*)$/After=$1 {}/".format(dbservice))
         utils.exec_cmd(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
There are 2 open PR's related to this #217, #262, and pending for a long time.

## Current behavior before PR:
The opendkim systemd start script does not wait for the DB to start

## Desired behavior after PR is merged:
The opendkim systemd start script will wait for the DB to start first.
It will handle both deb & rpm distributions, and mysql and postgresql>

I just tried to handle both linux distributions and the database service naming (mysql, mysql, postgresql)

I have deployed succesfully from this branch on Centos 7.7 droplet, with postgresql.

I have run into separate  issues due:
- SELinux (I run with SELinux enabled),
- the opendkim table in postgres had no rows, which prevented opendkim start
- letsencrypt renewals were failing, certbot could not find nginx (due to cron PATH)
- now letsencrypt renewalls work, but got blocked by letsencrypt due to rate limiting (the modoboa cronjob runs every 12h with `--force` option)

But it's running.
I will try to put together issues and fixes for the above.

When I have time I want to try installing on a fresh droplet, to try to catch other possible issues.

Thank you all, please review.