### PR TITLE
Configdicttemplate no postgres pass

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ The following components are installed by the installer:
 * Dovecot
 * Amavis (with SpamAssassin and ClamAV)
 * automx (autoconfiguration service)
+* OpenDKIM
+* Radicale (CalDAV and CardDAV server)
 
 If you want to customize configuration before running the installer,
 run the following command::
@@ -65,6 +67,22 @@ a previous one using the ``--version`` option::
 
 If you want more information about the installation process, add the
 ``--debug`` option to your command line.
+
+Upgrade mode
+------------
+
+An experimental upgrade mode is available.
+
+.. note::
+
+   You must keep the original configuration file, ie the one used for
+   the installation. Otherwise, you won't be able to use this mode.
+
+You can activate it as follows::
+
+  $ sudo ./run.py --upgrade <your domain>
+
+It will automatically install latest versions of modoboa and its plugins.
 
 Change the generated hostname
 -----------------------------

--- a/modoboa_installer/config_dict_template.py
+++ b/modoboa_installer/config_dict_template.py
@@ -86,7 +86,7 @@ ConfigDictTemplate = [
             },
             {
                 "option": "password",
-                "default": "",
+                "default": make_password,
                 "customizable": True,
                 "question": "Please enter postgres password",
             },

--- a/modoboa_installer/scripts/__init__.py
+++ b/modoboa_installer/scripts/__init__.py
@@ -6,7 +6,7 @@ import sys
 from .. import utils
 
 
-def install(appname, config):
+def install(appname, config, upgrade):
     """Install an application."""
     if (config.has_option(appname, "enabled") and
             not config.getboolean(appname, "enabled")):
@@ -19,7 +19,7 @@ def install(appname, config):
         print("Unknown application {}".format(appname))
         sys.exit(1)
     try:
-        getattr(script, appname.capitalize())(config).run()
+        getattr(script, appname.capitalize())(config, upgrade).run()
     except utils.FatalError as inst:
         utils.printcolor(u"{}".format(inst), utils.RED)
         sys.exit(1)

--- a/modoboa_installer/scripts/amavis.py
+++ b/modoboa_installer/scripts/amavis.py
@@ -85,5 +85,5 @@ class Amavis(base.Installer):
         """Additional tasks."""
         with open("/etc/mailname", "w") as fp:
             fp.write("{}\n".format(self.config.get("general", "hostname")))
-        install("spamassassin", self.config)
-        install("clamav", self.config)
+        install("spamassassin", self.config, self.upgrade)
+        install("clamav", self.config, self.upgrade)

--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -24,11 +24,11 @@ class Automx(base.Installer):
     }
     with_user = True
 
-    def __init__(self, config):
+    def __init__(self, *args, **kwargs):
         """Get configuration."""
-        super(Automx, self).__init__(config)
-        self.venv_path = config.get("automx", "venv_path")
-        self.instance_path = config.get("automx", "instance_path")
+        super(Automx, self).__init__(*args, **kwargs)
+        self.venv_path = self.config.get("automx", "venv_path")
+        self.instance_path = self.config.get("automx", "instance_path")
 
     def get_template_context(self):
         """Additional variables."""

--- a/modoboa_installer/scripts/base.py
+++ b/modoboa_installer/scripts/base.py
@@ -19,9 +19,10 @@ class Installer(object):
     with_db = False
     config_files = []
 
-    def __init__(self, config):
+    def __init__(self, config, upgrade):
         """Get configuration."""
         self.config = config
+        self.upgrade = upgrade
         if self.config.has_section(self.appname):
             self.app_config = dict(self.config.items(self.appname))
         self.dbengine = self.config.get("database", "engine")
@@ -67,8 +68,8 @@ class Installer(object):
             self.backend.load_sql_file(
                 self.dbname, self.dbuser, self.dbpasswd, schema)
 
-    def create_user(self):
-        """Create a system user."""
+    def setup_user(self):
+        """Setup a system user."""
         if not self.with_user:
             return
         self.user = self.config.get(self.appname, "user")
@@ -143,8 +144,9 @@ class Installer(object):
     def run(self):
         """Run the installer."""
         self.install_packages()
-        self.create_user()
-        self.setup_database()
+        self.setup_user()
+        if not self.upgrade:
+            self.setup_database()
         self.install_config_files()
         self.post_run()
         self.restart_daemon()

--- a/modoboa_installer/scripts/nginx.py
+++ b/modoboa_installer/scripts/nginx.py
@@ -25,7 +25,8 @@ class Nginx(base.Installer):
         context.update({
             "app_instance_path": (
                 self.config.get(app, "instance_path")),
-            "uwsgi_socket_path": Uwsgi(self.config).get_socket_path(app)
+            "uwsgi_socket_path": (
+                Uwsgi(self.config, self.upgrade).get_socket_path(app))
         })
         return context
 

--- a/modoboa_installer/scripts/postfix.py
+++ b/modoboa_installer/scripts/postfix.py
@@ -97,4 +97,4 @@ class Postfix(base.Installer):
             utils.exec_cmd("postalias {}".format(aliases_file))
 
         # Postwhite
-        install("postwhite", self.config)
+        install("postwhite", self.config, self.upgrade)

--- a/modoboa_installer/scripts/radicale.py
+++ b/modoboa_installer/scripts/radicale.py
@@ -22,10 +22,10 @@ class Radicale(base.Installer):
     }
     with_user = True
 
-    def __init__(self, config):
+    def __init__(self, *args, **kwargs):
         """Get configuration."""
-        super(Radicale, self).__init__(config)
-        self.venv_path = config.get("radicale", "venv_path")
+        super(Radicale, self).__init__(*args, **kwargs)
+        self.venv_path = self.config.get("radicale", "venv_path")
 
     def _setup_venv(self):
         """Prepare a dedicated virtualenv."""

--- a/modoboa_installer/scripts/spamassassin.py
+++ b/modoboa_installer/scripts/spamassassin.py
@@ -61,7 +61,7 @@ class Spamassassin(base.Installer):
             "pyzor --homedir {} discover".format(pw[5]),
             sudo_user=amavis_user, login=False
         )
-        install("razor", self.config)
+        install("razor", self.config, self.upgrade)
         if utils.dist_name() in ["debian", "ubuntu"]:
             utils.exec_cmd(
                 "perl -pi -e 's/^CRON=0/CRON=1/' /etc/cron.daily/spamassassin")

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -145,10 +145,15 @@ def copy_from_template(template, dest, context):
         fp.write(ConfigFileTemplate(buf).substitute(context))
 
 
-def check_config_file(dest, interactive=False):
+def check_config_file(dest, interactive=False, upgrade=False):
     """Create a new installer config file if needed."""
     if os.path.exists(dest):
         return
+    if upgrade:
+        printcolor(
+            "You cannot upgrade an existing installation without a "
+            "configuration file.", RED)
+        sys.exit(1)
     printcolor(
         "Configuration file {} not found, creating new one."
         .format(dest), YELLOW)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This is to address #296 

Current behavior before PR:
no password generated for postgres after running `modoboa-installer`

Desired behavior after PR is merged:
after running `modoboa-installer`

See:
https://github.com/modoboa/modoboa-installer/issues/296