### PR TITLE
Use bistro package in utils.dist_name if it exists

### DIFF
--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -76,11 +76,11 @@ def exec_cmd(cmd, sudo_user=None, pinput=None, login=True, **kwargs):
 def dist_name():
     """Try to guess the distribution name."""
     try:
-        # Python 3.7 and up way
+        # Python 3.8 and up way
         import distro
         name, version, _id = distro.linux_distribution()
     except ModuleNotFoundError as e:
-        # Python 3.6 and down way
+        # Python 3.7 and down way
         import platform
         name, version, _id = platform.linux_distribution()
     return "unknown" if not name else name.lower()

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -4,7 +4,6 @@ import contextlib
 import datetime
 import glob
 import os
-import platform
 import random
 import shutil
 import string
@@ -76,7 +75,14 @@ def exec_cmd(cmd, sudo_user=None, pinput=None, login=True, **kwargs):
 
 def dist_name():
     """Try to guess the distribution name."""
-    name, version, _id = platform.linux_distribution()
+    try:
+        # Python 3.7 and up way
+        import distro
+        name, version, _id = distro.linux_distribution()
+    except ModuleNotFoundError as e:
+        # Python 3.6 and down way
+        import platform
+        name, version, _id = platform.linux_distribution()
     return "unknown" if not name else name.lower()
 
 

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -79,7 +79,7 @@ def dist_name():
         # Python 3.8 and up way
         import distro
         name, version, _id = distro.linux_distribution()
-    except ModuleNotFoundError as e:
+    except ImportError as e:
         # Python 3.7 and down way
         import platform
         name, version, _id = platform.linux_distribution()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  
This fixes issue the first error in #314 since Ubuntu 20.04 uses Python 3.8.

Current behavior before PR:  
The installer does not run on python 3.8.

Desired behavior after PR is merged:  
Installer runs on all versions of python including 3.8

This was tested on: 
- Ubuntu 18/Python 3.6.9:  Result 'ubuntu'
- Ubuntu 20/Python 3.8.2:  Result 'ubuntu'
- Debian 10/Python 3.7.3:  Result 'debian'
- MacOS 10.15.4/Python 3.7.5:  Result 'unknown'

