### PR TITLE
update database.py distro detection

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -1,7 +1,7 @@
 """Database related tools."""
 
 import os
-import platform
+import distro
 import pwd
 import stat
 
@@ -143,7 +143,7 @@ class MySQL(Database):
 
     def install_package(self):
         """Preseed package installation."""
-        name, version, _id = platform.linux_distribution()
+        name, version, _id = distro.linux_distribution()
         name = name.lower()
         if name == "debian":
             mysql_name = "mysql" if version.startswith("8") else "mariadb"


### PR DESCRIPTION
### Info
platform module is deprecated beginning with Python 3.7. 
So distro module should be used instead.

### Description of the issue/feature this PR addresses:
When you run the installer. It runs database.py this tries to detected what Linux distribution you are using but fails. Withe the Error:
`AttributeError: module 'platform' has no attribute 'linux_distribution'`  
### Current behavior before PR:
Python outputs `AttributeError: module 'platform' has no attribute 'linux_distribution'`
### Desired behavior after PR is merged:
Script runs successfully on > python 3.7 as it manages to detect Linux distribution 
