### PR TITLE
Debian buster 10.6 with Letsencrypt: installation failed on distro name check in ssl.py

### DIFF
--- a/modoboa_installer/ssl.py
+++ b/modoboa_installer/ssl.py
@@ -83,7 +83,7 @@ class LetsEncryptCertificate(CertificateBackend):
                 utils.exec_cmd("add-apt-repository -y ppa:certbot/certbot")
             package.backend.update()
             package.backend.install("certbot")
-        elif name == "Debian":
+        elif name == "Debian" or name == "debian":
             package.backend.update()
             package.backend.install("certbot")
         elif "CentOS" in name:

--- a/modoboa_installer/ssl.py
+++ b/modoboa_installer/ssl.py
@@ -83,7 +83,7 @@ class LetsEncryptCertificate(CertificateBackend):
                 utils.exec_cmd("add-apt-repository -y ppa:certbot/certbot")
             package.backend.update()
             package.backend.install("certbot")
-        elif name == "Debian" or name == "debian":
+        elif name.lower() == "debian":
             package.backend.update()
             package.backend.install("certbot")
         elif "CentOS" in name:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
On Debian Buster 10.6, the installation fails when using letsencrypt for generating certificates.

**Current behavior before PR:**
Installation failed with error:
```
Starting...
Generating new certificate using letsencrypt
Failed to install certbot, aborting.
```
Python's `platform.linux_distribution()` returns "debian" starting with a small letter:
```
>>> platform.linux_distribution()
__main__:1: DeprecationWarning: dist() and linux_distribution() functions are deprecated in Python 3.5
('debian', '10.6', '')
```
In `ssl.py` the distro's name only gets checked for "Debian" (capital letter), thus failing the installation.

**Desired behavior after PR is merged:**
Installation continuing properly