### PR TITLE
Update Postfix main.cf template to allow IPv6

### DIFF
--- a/modoboa_installer/scripts/files/postfix/main.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/main.cf.tpl
@@ -1,5 +1,5 @@
 inet_interfaces = all
-inet_protocols = ipv4
+inet_protocols = all
 myhostname = %hostname
 myorigin = $myhostname
 mydestination = $myhostname


### PR DESCRIPTION
setting inet_protocols to all allows Postfix to use IPv6 if available on a host

fixes issue #344

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
