### PR TITLE
Fix PostgreSQL URI

### DIFF
--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -34,7 +34,7 @@ class Automx(base.Installer):
         """Additional variables."""
         context = super(Automx, self).get_template_context()
         sql_dsn = "{}://{}:{}@{}/{}".format(
-            self.dbengine,
+            "postgresql" if self.dbengine == "postgres" else self.dbengine,
             self.config.get("modoboa", "dbuser"),
             self.config.get("modoboa", "dbpassword"),
             self.dbhost,


### PR DESCRIPTION
SQLAlchemy removed support for `postgres://`, the URI has to start with `postgresql://`.

Description of the issue/feature this PR addresses:
https://github.com/modoboa/modoboa-installer/issues/396

Current behavior before PR:
Bad URI for PostgreSQL query in `/etc/automx.conf` leads to `${email}` in generated XML instead of the username.

Desired behavior after PR is merged:
Get the mail address as the username.