### PR TITLE
Ensure redis server is started

### DIFF
--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -271,6 +271,7 @@ class Modoboa(base.Installer):
             system.enable_and_start_service("redis")
         else:
             supervisor = "supervisor"
+            system.enable_and_start_service("redis-server")
         # Restart supervisor
         system.enable_service(supervisor)
         utils.exec_cmd("service {} stop".format(supervisor))


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

On Debian-based systems, since commit 6fdf57b, the Redis server is not started during execution of the installer.

### Current behavior before PR

Redis server not started, so not available after installation.

### Desired behavior after PR is merged

Redis server started.
