### PR TITLE
Have amavis as dedicated lmtp instead of proxy-filter

### DIFF
--- a/modoboa_installer/config_dict_template.py
+++ b/modoboa_installer/config_dict_template.py
@@ -210,7 +210,7 @@ ConfigDictTemplate = [
             },
             {
                 "option": "max_servers",
-                "default": "1",
+                "default": "2",
             },
             {
                 "option": "dbname",

--- a/modoboa_installer/scripts/files/postfix/main.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/main.cf.tpl
@@ -115,6 +115,9 @@ strict_rfc821_envelopes = yes
 %{opendkim_enabled}milter_default_action = accept
 %{opendkim_enabled}milter_content_timeout = 30s
 
+#Amavis setup
+%{amavis_enabled}content_filter = smtp-amavis:[127.0.0.1]:10024
+
 # List of authorized senders
 smtpd_sender_login_maps =
         proxy:%{db_driver}:/etc/postfix/sql-sender-login-map.cf

--- a/modoboa_installer/scripts/files/postfix/master.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/master.cf.tpl
@@ -11,8 +11,11 @@
 # ==========================================================================
 smtp      inet  n       -       -       -       1       postscreen
 smtpd     pass  -       -       -       -       -       smtpd
-%{amavis_enabled}  -o smtpd_proxy_filter=inet:[127.0.0.1]:10024 
-%{amavis_enabled}  -o smtpd_proxy_options=speed_adjust
+%{amavis_enabled}smtp-amavis unix    -       -       n        -      2     lmtp
+%{amavis_enabled}  -o lmtp_data_done_timeout=1200
+%{amavis_enabled}  -o lmtp_send_xforward_command=yes
+%{amavis_enabled}  -o disable_dns_lookups=yes
+%{amavis_enabled}  -o max_use=20
 dnsblog   unix  -       -       -       -       0       dnsblog
 
 tlsproxy  unix  -       -       -       -       0       tlsproxy


### PR DESCRIPTION
Amavis is currently running while receiving the mail, this has the advantage to reject mails if they are suspicious or with unwanted file. However, it also means that amavis has a restricted time to check the mail before the connection with remote smtp close. This cause random ``451 4.3.0 Error: queue file write error``. 

Looking at [amavis doc](https://amavis.org/README.postfix.html#basics_transport) they suggest using a dedicated ltmp instead of a proxy filter as it is currently implemented.

This MR is to set it up as dedicated. This has the advantage to not reject mails and be able to take more time for checking. I also included a change about default $max_server (1-->2) for more stability (doesn't increase load that much).

Related issues : modoboa/modoboa#2564 and potentially modoboa/modoboa#2475