### PR TITLE
mitigate false spamhaus reject

### DIFF
--- a/modoboa_installer/scripts/files/postfix/main.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/main.cf.tpl
@@ -142,7 +142,7 @@ postscreen_blacklist_action = enforce
 
 # Use some DNSBL
 postscreen_dnsbl_sites = 
-	zen.spamhaus.org*3
+	zen.spamhaus.org=127.0.0.[2..11]*3
 	bl.spameatingmonkey.net*2
 	bl.spamcop.net
 	dnsbl.sorbs.net

--- a/modoboa_installer/scripts/files/postfix/main.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/main.cf.tpl
@@ -143,9 +143,9 @@ postscreen_blacklist_action = enforce
 # Use some DNSBL
 postscreen_dnsbl_sites = 
 	zen.spamhaus.org=127.0.0.[2..11]*3
-	bl.spameatingmonkey.net*2
-	bl.spamcop.net
-	dnsbl.sorbs.net
+	bl.spameatingmonkey.net=127.0.0.2*2
+	bl.spamcop.net=127.0.0.2
+	dnsbl.sorbs.net=127.0.0.[2..15]
 postscreen_dnsbl_threshold = 3 
 postscreen_dnsbl_action = enforce 
 


### PR DESCRIPTION
Since 2021, spamhaus now requires that your dns resolver has a non-generic rDns set up. 

Since modoboa doesn't set one as MIAB could do, spamhaus has high chance to send back 127.255.255.254 to a lot of users. Postifx should only treat answer between 1 and 11. 
