### PR TITLE
Fix permissions for modoboa dovecot mailbox commands (modoboa/modoboa…

### DIFF
--- a/modoboa_installer/scripts/dovecot.py
+++ b/modoboa_installer/scripts/dovecot.py
@@ -104,6 +104,12 @@ class Dovecot(base.Installer):
             utils.copy_file(f, "{}/conf.d".format(self.config_dir))
         # Make postlogin script executable
         utils.exec_cmd("chmod +x /usr/local/bin/postlogin.sh")
+        # Add mailboxes user to dovecot group for modoboa mailbox commands.
+        # See https://github.com/modoboa/modoboa/issues/2157.
+        system.add_user_to_group(
+            self.config.get("dovecot", "mailboxes_owner"),
+            'dovecot'
+        )
 
     def restart_daemon(self):
         """Restart daemon process.


### PR DESCRIPTION
…/issues/2157)

Description of the issue/feature this PR addresses:

Modoboa claims that it has removed a user account (and domain).
It no longer appears within the web interface, however, you can still find data for account and domain within the `vmail` directory on the server.

Current behavior before PR:

Modoboa executes `doveadm` as user `vmail` to remove/rename mailbox folders in `/srv/vmail/$domain`. However, due to lack of authorization, the command fails silently. 

Desired behavior after PR is merged:

Modoboa mailbox filesystem management commands do what they are supposed to do. 
