### PR TITLE
removed libmysqlclient-dev

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -153,7 +153,7 @@ class MySQL(Database):
 
     default_port = 3306
     packages = {
-        "deb": ["mariadb-server", "libmysqlclient-dev"],
+        "deb": ["mariadb-server"],
         "rpm": ["mariadb", "mariadb-devel", "mariadb-server"],
     }
     service = "mariadb"


### PR DESCRIPTION
Fixed change introduced with #428. The bug comes from the fact that user disabled db install in the config. This will require a more in depth fix.
