### PR TITLE
Set $max_server to 2 to avoid amavis crash

### DIFF
--- a/modoboa_installer/config_dict_template.py
+++ b/modoboa_installer/config_dict_template.py
@@ -210,7 +210,7 @@ ConfigDictTemplate = [
             },
             {
                 "option": "max_servers",
-                "default": "1",
+                "default": "2",
             },
             {
                 "option": "dbname",


### PR DESCRIPTION
A bunch of user are reporting errors, likely due to the fact that by default max_server is at one, so ounce the child number has been achieved (20 by default) the process is terminated, ending by a queue file error.
