### PR TITLE
Fixes ssl permission error, updated ssl_protocol parameter

### DIFF
--- a/modoboa_installer/scripts/dovecot.py
+++ b/modoboa_installer/scripts/dovecot.py
@@ -26,7 +26,7 @@ class Dovecot(base.Installer):
     }
     config_files = [
         "dovecot.conf", "dovecot-dict-sql.conf.ext", "conf.d/10-ssl.conf",
-        "conf.d/10-master.conf", "conf.d/20-lmtp.conf"]
+        "conf.d/10-master.conf", "conf.d/20-lmtp.conf", "conf.d/10-ssl-keys.try"]
     with_user = True
 
     def get_config_files(self):
@@ -58,8 +58,13 @@ class Dovecot(base.Installer):
         """Additional variables."""
         context = super(Dovecot, self).get_template_context()
         pw = pwd.getpwnam(self.user)
+        dovecot_package = {"deb": "dovecot-core", "rpm": "dovecot"}
+        ssl_protocol_parameter = "ssl_protocols"
+        if package.backend.get_installed_version(dovecot_package[package.backend.FORMAT]).startswith("2.3"):
+            ssl_protocol_parameter = "ssl_min_protocol"
         ssl_protocols = "!SSLv2 !SSLv3"
-        if package.backend.get_installed_version("openssl").startswith("1.1"):
+        if package.backend.get_installed_version("openssl").startswith("1.1") \
+                or package.backend.get_installed_version("openssl").startswith("3"):
             ssl_protocols = "!SSLv3"
         if "centos" in utils.dist_name():
             protocols = "protocols = imap lmtp sieve"
@@ -79,6 +84,7 @@ class Dovecot(base.Installer):
             "modoboa_dbpassword": self.config.get("modoboa", "dbpassword"),
             "protocols": protocols,
             "ssl_protocols": ssl_protocols,
+            "ssl_protocol_parameter": ssl_protocol_parameter,
             "radicale_user": self.config.get("radicale", "user"),
             "radicale_auth_socket_path": os.path.basename(
                 self.config.get("dovecot", "radicale_auth_socket_path"))

--- a/modoboa_installer/scripts/dovecot.py
+++ b/modoboa_installer/scripts/dovecot.py
@@ -60,7 +60,7 @@ class Dovecot(base.Installer):
         pw = pwd.getpwnam(self.user)
         dovecot_package = {"deb": "dovecot-core", "rpm": "dovecot"}
         ssl_protocol_parameter = "ssl_protocols"
-        if package.backend.get_installed_version(dovecot_package[package.backend.FORMAT]).startswith("2.3"):
+        if package.backend.get_installed_version(dovecot_package[package.backend.FORMAT]) > "2.3":
             ssl_protocol_parameter = "ssl_min_protocol"
         ssl_protocols = "!SSLv2 !SSLv3"
         if package.backend.get_installed_version("openssl").startswith("1.1") \

--- a/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl-keys.try.tpl
+++ b/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl-keys.try.tpl
@@ -1,0 +1,6 @@
+# PEM encoded X.509 SSL/TLS certificate and private key. They're opened before
+# dropping root privileges, so keep the key file unreadable by anyone but
+# root. Included doc/mkcert.sh can be used to easily generate self-signed
+# certificate, just make sure to update the domains in dovecot-openssl.cnf
+ssl_cert = <%tls_cert_file
+ssl_key = <%tls_key_file

--- a/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
+++ b/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
@@ -5,12 +5,11 @@
 # SSL/TLS support: yes, no, required. <doc/wiki/SSL.txt>
 #ssl = yes
 
-# PEM encoded X.509 SSL/TLS certificate and private key. They're opened before
-# dropping root privileges, so keep the key file unreadable by anyone but
-# root. Included doc/mkcert.sh can be used to easily generate self-signed
-# certificate, just make sure to update the domains in dovecot-openssl.cnf
-ssl_cert = <%tls_cert_file
-ssl_key = <%tls_key_file
+# Workarround https://github.com/modoboa/modoboa/issues/2570 
+# We try to load the key and pass if it fails
+# Keys require root permissions, standard commands would be blocked
+# by permissions
+!include_try = /etc/dovecot/conf.d/10-ssl-keys.try
 
 # If key file is password protected, give the password here. Alternatively
 # give it when starting dovecot with -p parameter. Since this file is often
@@ -41,7 +40,7 @@ ssl_key = <%tls_key_file
 #ssl_parameters_regenerate = 168
 
 # SSL protocols to use
-ssl_protocols = %ssl_protocols
+%ssl_protocol_parameter = %ssl_protocols
 
 
 # SSL ciphers to use

--- a/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
+++ b/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
@@ -8,7 +8,7 @@
 # Workarround https://github.com/modoboa/modoboa/issues/2570 
 # We try to load the key and pass if it fails
 # Keys require root permissions, standard commands would be blocked
-# by permissions
+# because dovecot can't load these cert
 !include_try = /etc/dovecot/conf.d/10-ssl-keys.try
 
 # If key file is password protected, give the password here. Alternatively


### PR DESCRIPTION
Fixes modoboa/modoboa#2570. It also updates ssl_protocols to ssl_min_protocol (https://doc.dovecot.org/installation_guide/upgrading/from-2.2-to-2.3/).