### PR TITLE
fixed ssl_min_protocol setting

### DIFF
--- a/modoboa_installer/scripts/dovecot.py
+++ b/modoboa_installer/scripts/dovecot.py
@@ -66,6 +66,8 @@ class Dovecot(base.Installer):
         if package.backend.get_installed_version("openssl").startswith("1.1") \
                 or package.backend.get_installed_version("openssl").startswith("3"):
             ssl_protocols = "!SSLv3"
+        if ssl_protocol_parameter == "ssl_min_protocol":
+            ssl_protocols = "TLSv1"
         if "centos" in utils.dist_name():
             protocols = "protocols = imap lmtp sieve"
             extra_protocols = self.config.get("dovecot", "extra_protocols")


### PR DESCRIPTION
In precedent PR (#445) dovecot configuration syntax was updated, but I forgot to update the right part.
`TLSv1` is the [new way of saying](https://doc.dovecot.org/settings/core/?highlight=ssl_min_protocol#core_setting-ssl_min_protocol) `!SSLv3` with `ssl_min_protocol`