### PR TITLE
Update scripts/modoboa.py to fix install error

### DIFF
--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -198,7 +198,7 @@ class Modoboa(base.Installer):
             if db_dump_path is not None:
                 return db_dump_path
 
-        return super().get_sql_schema_path()()
+        return super().get_sql_schema_path()
 
     def get_packages(self):
         """Include extra packages if needed."""


### PR DESCRIPTION
```
[...]
Installing modoboa
User modoboa already exists, skipping creation but please make sure the /srv/modoboa directory exists.
Traceback (most recent call last):
  File "/home/kevin/modoboa-installer/./run.py", line 208, in <module>
    main(sys.argv[1:])
  File "/home/kevin/modoboa-installer/./run.py", line 185, in main
    scripts.install("modoboa", config, args.upgrade, args.restore)
  File "/home/kevin/modoboa-installer/modoboa_installer/scripts/__init__.py", line 23, in install
    getattr(script, appname.capitalize())(config, upgrade, restore).run()
  File "/home/kevin/modoboa-installer/modoboa_installer/scripts/base.py", line 158, in run
    self.setup_database()
  File "/home/kevin/modoboa-installer/modoboa_installer/scripts/modoboa.py", line 189, in setup_database
    super(Modoboa, self).setup_database()
  File "/home/kevin/modoboa-installer/modoboa_installer/scripts/base.py", line 70, in setup_database
    schema = self.get_sql_schema_path()
  File "/home/kevin/modoboa-installer/modoboa_installer/scripts/modoboa.py", line 201, in get_sql_schema_path
    return super().get_sql_schema_path()()
TypeError: 'NoneType' object is not callable
```

Description of the issue/feature this PR addresses: Wanted to fix this error I got during installation on a fresh Ubuntu server.
Current behavior before PR: Doesn't install
Desired behavior after PR is merged: Installs
