### PR TITLE
fix typo in dovecot configuration file

### DIFF
--- a/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
+++ b/modoboa_installer/scripts/files/dovecot/conf.d/10-ssl.conf.tpl
@@ -9,7 +9,7 @@
 # We try to load the key and pass if it fails
 # Keys require root permissions, standard commands would be blocked
 # because dovecot can't load these cert
-!include_try = /etc/dovecot/conf.d/10-ssl-keys.try
+!include_try /etc/dovecot/conf.d/10-ssl-keys.try
 
 # If key file is password protected, give the password here. Alternatively
 # give it when starting dovecot with -p parameter. Since this file is often


### PR DESCRIPTION
`!include_try` does not take a `=`