### PR TITLE
fixed dkim permissions

### DIFF
--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -115,13 +115,17 @@ class Opendkim(base.Installer):
         """Restore keys."""
         dkim_keys_backup = os.path.join(
             self.archive_path, "custom/dkim")
+        keys_storage_dir = self.config.get(
+            "opendkim", "keys_storage_dir", fallback="/var/lib/dkim")
         if os.path.isdir(dkim_keys_backup):
             for file in os.listdir(dkim_keys_backup):
                 file_path = os.path.join(dkim_keys_backup, file)
                 if os.path.isfile(file_path):
-                    utils.copy_file(file_path, self.config.get(
-                        "opendkim", "keys_storage_dir", fallback="/var/lib/dkim"))
+                    utils.copy_file(file_path, keys_storage_dir)
             utils.success("DKIM keys restored from backup")
+        # Setup permissions
+        user = self.config.get("opendkim", "user")
+        utils.exec_cmd(f"chown -R {user}:{user} {keys_storage_dir}")
 
     def custom_backup(self, path):
         """Backup DKIM keys."""

--- a/modoboa_installer/scripts/opendkim.py
+++ b/modoboa_installer/scripts/opendkim.py
@@ -115,8 +115,7 @@ class Opendkim(base.Installer):
         """Restore keys."""
         dkim_keys_backup = os.path.join(
             self.archive_path, "custom/dkim")
-        keys_storage_dir = self.config.get(
-            "opendkim", "keys_storage_dir", fallback="/var/lib/dkim")
+        keys_storage_dir = self.app_config["keys_storage_dir"]
         if os.path.isdir(dkim_keys_backup):
             for file in os.listdir(dkim_keys_backup):
                 file_path = os.path.join(dkim_keys_backup, file)
@@ -129,9 +128,7 @@ class Opendkim(base.Installer):
 
     def custom_backup(self, path):
         """Backup DKIM keys."""
-        storage_dir = self.config.get(
-            "opendkim", "keys_storage_dir", fallback="/var/lib/dkim")
-        if os.path.isdir(storage_dir):
-            shutil.copytree(storage_dir, os.path.join(path, "dkim"))
+        if os.path.isdir(self.app_config["keys_storage_dir"]):
+            shutil.copytree(self.app_config["keys_storage_dir"], os.path.join(path, "dkim"))
             utils.printcolor(
                 "DKIM keys saved!", utils.GREEN)


### PR DESCRIPTION
When restoring from backup, dkim keys are restored as root, whereas opendkim needs it to be its own user. 