### PR TITLE
randomize api call time

### DIFF
--- a/modoboa_installer/scripts/files/modoboa/crontab.tpl
+++ b/modoboa_installer/scripts/files/modoboa/crontab.tpl
@@ -30,7 +30,7 @@ INSTANCE=%{instance_path}
 */30    *       *       *       *       root    $PYTHON $INSTANCE/manage.py modo check_mx
 
 # Public API communication
-0       *       *       *       *       root    $PYTHON $INSTANCE/manage.py communicate_with_public_api
+%{minute}       %{hours}       *       *       *       root    $PYTHON $INSTANCE/manage.py communicate_with_public_api
 
 # Generate DKIM keys (they will belong to the user running this job)
 %{opendkim_enabled}*       *       *       *       *       %{opendkim_user}    umask 077 && $PYTHON $INSTANCE/manage.py modo manage_dkim_keys

--- a/modoboa_installer/scripts/files/modoboa/crontab.tpl
+++ b/modoboa_installer/scripts/files/modoboa/crontab.tpl
@@ -30,7 +30,7 @@ INSTANCE=%{instance_path}
 */30    *       *       *       *       root    $PYTHON $INSTANCE/manage.py modo check_mx
 
 # Public API communication
-%{minute}       %{hours}       *       *       *       root    $PYTHON $INSTANCE/manage.py communicate_with_public_api
+%{minutes}       %{hours}       *       *       *       root    $PYTHON $INSTANCE/manage.py communicate_with_public_api
 
 # Generate DKIM keys (they will belong to the user running this job)
 %{opendkim_enabled}*       *       *       *       *       %{opendkim_user}    umask 077 && $PYTHON $INSTANCE/manage.py modo manage_dkim_keys

--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -230,7 +230,7 @@ class Modoboa(base.Installer):
             "radicale_enabled": (
                 "" if "modoboa-radicale" in extensions else "#"),
             "opendkim_user": self.config.get("opendkim", "user"),
-            "minute": random.randint(1, 59),
+            "minutes": random.randint(1, 59),
             "hours" : f"{random_hour},{random_hour+12}"
         })
         return context

--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -3,6 +3,7 @@
 import json
 import os
 import pwd
+import random
 import shutil
 import stat
 import sys
@@ -219,6 +220,7 @@ class Modoboa(base.Installer):
         context = super(Modoboa, self).get_template_context()
         extensions = self.config.get("modoboa", "extensions")
         extensions = extensions.split()
+        random_hour = random.randint(0, 6)
         context.update({
             "sudo_user": (
                 "uwsgi" if package.backend.FORMAT == "rpm" else context["user"]
@@ -228,6 +230,8 @@ class Modoboa(base.Installer):
             "radicale_enabled": (
                 "" if "modoboa-radicale" in extensions else "#"),
             "opendkim_user": self.config.get("opendkim", "user"),
+            "minute": random.randint(1, 59),
+            "hours" : f"{random_hour},{random_hour+12}"
         })
         return context
 


### PR DESCRIPTION
Avoid public api to crash due to high amount of clients connecting at the same time.