### PR TITLE
Make DNS understaind easier for users

### DIFF
--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ def installation_disclaimer(args, config):
         "Before you start the installation, please make sure the following "
         "DNS records exist for domain '{}':\n"
         "  {} IN A   <IP ADDRESS OF YOUR SERVER>\n"
-        "       IN MX  {}.\n".format(
+        "     @ IN MX  {}.\n".format(
             args.domain,
             hostname.replace(".{}".format(args.domain), ""),
             hostname


### PR DESCRIPTION
This simple change makes it easier for new users to add the DNS records they need for there Modoboa installation.

Description of the issue/feature this PR addresses:
The original issue was that people had a hard time understanding what the `Name` for the `MX` record should be. The `@` displays that it is the root of the domain; which people are able to comprehend better.

Current behavior before PR:
Does not display a `@` symbol in front of the `MX` record.

Desired behavior after PR is merged:
Displays an `@` symbol before the ` IN MX mail.example.com.`