### PR TITLE
Fixed permissions of /etc/dovecot/conf.d/10-ssl-keys.try to resolve issue #2570

### DIFF
--- a/modoboa_installer/scripts/dovecot.py
+++ b/modoboa_installer/scripts/dovecot.py
@@ -120,6 +120,9 @@ class Dovecot(base.Installer):
             utils.copy_file(f, "{}/conf.d".format(self.config_dir))
         # Make postlogin script executable
         utils.exec_cmd("chmod +x /usr/local/bin/postlogin.sh")
+        # Only root should have read access to the 10-ssl-keys.try
+        # See https://github.com/modoboa/modoboa/issues/2570
+        utils.exec_cmd("chmod 600 /etc/dovecot/conf.d/10-ssl-keys.try")
         # Add mailboxes user to dovecot group for modoboa mailbox commands.
         # See https://github.com/modoboa/modoboa/issues/2157.
         system.add_user_to_group(self.mailboxes_owner, 'dovecot')


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Resolves modoboa/modoboa#2570

When dovecot first starts up, `root` reads the dovecot conf and is able to read and load the keys in `/etc/dovecot/conf.d/10-ssl-keys.try` Inside that file, it can read the private key (that only root has permissions to read)

However when we try delete a user, `doveconf` tries to read the config (to find the user's mailbox) `doveconf` MUST fail to open `10-ssl-keys.try`, which is fine, because `10-ssl.conf` says
```
!include_try /etc/dovecot/conf.d/10-ssl-keys.try
```
So if `doveconf` can't open `10-ssl-keys.try` it will will keep going. However if `doveconf` can read `10-ssl-keys.try` then `doveconf` crashes saying something like:
```
Failed to retrieve mailbox location (b doveconf: Fatal: Error in configuration file /etc/dovecot/conf.d/10-ssl-keys.try line 11: ssl_key: Can't open file /etc/ssl/example.com/privkey.pem: Permission denied
```
**And then the attempt to delete the user's mailbox fails.**

According to @gsloop, "the API calls doveadm to return the directory that holds the users mailbox"

I did a new installation, the file `/etc/dovecot/conf.d/10-ssl-keys.try` was already correctly owned by `root:root` but it had incorrect `644` permissions. So I added the line to `modoboa_installer/scripts/dovecot.py` that corrects that.

# Current behavior before PR:
Can't delete mailboxes, modoboa shows an error when `postconf` crashes trying to read the SSL private key file.
![image](https://user-images.githubusercontent.com/28704571/224301855-ee40a846-ced4-46ba-80a7-a0d37964308d.png)
Line 11 of `10-ssl-keys.try` contains `ssl_key = </path/to/privkey.pem`

# Desired behavior after PR is merged:
Can delete mailboxes successfully.
![image](https://user-images.githubusercontent.com/28704571/224339591-217aec23-e80c-4d11-90b4-ccd5a03d8959.png)
