### PR TITLE
Added workaround for ubuntu 20 and 22

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -183,7 +183,11 @@ class MySQL(Database):
             else:
                 self.packages["deb"].append("libmariadbclient-dev")
         elif name == "ubuntu":
-            self.packages["deb"].append("libmysqlclient-dev")
+            if version.startswith("2"):
+                # Works for Ubuntu 22 and 20
+                self.packages["deb"].append("libmariadb-dev")
+            else:
+                self.packages["deb"].append("libmysqlclient-dev")
         super(MySQL, self).install_package()
         queries = []
         if name.startswith("debian"):
@@ -201,6 +205,12 @@ class MySQL(Database):
                     .format(self.dbpassword),
                     "flush privileges"
                 ]
+        if name.startswith("ubuntu") and version.startswith("22"):
+            queries = [
+                "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('{}')"
+                .format(self.dbpassword),
+                "flush privileges"
+            ]
         if not queries:
             queries = [
                 "UPDATE user SET plugin='' WHERE user='root'",


### PR DESCRIPTION
Reported on discord. Updated database setup for ubuntu 22 and make use of libmariadb-dev for ubuntu 20 and 22.