### PR TITLE
Fix http2 wrong port

### DIFF
--- a/modoboa_installer/scripts/files/nginx/automx.conf.tpl
+++ b/modoboa_installer/scripts/files/nginx/automx.conf.tpl
@@ -3,8 +3,8 @@ upstream automx {
 }
 
 server {
-    listen 80 http2;
-    listen [::]:80 http2;
+    listen 80;
+    listen [::]:80;
     server_name %hostname;
     root /srv/automx/instance;
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
http2 should only be issued for 443

Current behavior before PR:
Wrong configuration

Desired behavior after PR is merged:

All working the right way