### PR TITLE
Automx fix

### DIFF
--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -68,12 +68,13 @@ class Automx(base.Installer):
             packages.append("mysqlclient")
         python.install_packages(packages, self.venv_path, sudo_user=self.user)
         target = "{}/master.zip".format(self.home_dir)
-        utils.download_remote_file("https://github.com/sys4/automx/archive/master.zip", target)
+        downloaded_file_path = utils.download_remote_file("https://github.com/sys4/automx/archive/master.zip", target)
         self.repo_dir = "{}/automx-master".format(self.home_dir)
         if os.path.exists(self.repo_dir):
             shutil.rmtree(self.repo_dir)
+        # Use the absolute path of the downloaded file for the unzip command
         utils.exec_cmd(
-            "unzip master.zip", sudo_user=self.user, cwd=self.home_dir)
+            f"unzip {downloaded_file_path}", sudo_user=self.user, cwd=self.home_dir)
         utils.exec_cmd(
             "{} setup.py install".format(
                 python.get_path("python", self.venv_path)),

--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -68,24 +68,12 @@ class Automx(base.Installer):
             packages.append("mysqlclient")
         python.install_packages(packages, self.venv_path, sudo_user=self.user)
         target = "{}/master.zip".format(self.home_dir)
-        if os.path.exists(target):
-            os.unlink(target)
-        utils.exec_cmd(
-            "wget https://github.com/sys4/automx/archive/master.zip",
-            sudo_user=self.user, cwd=self.home_dir)
+        utils.download_remote_file("https://github.com/sys4/automx/archive/master.zip", target)
         self.repo_dir = "{}/automx-master".format(self.home_dir)
         if os.path.exists(self.repo_dir):
             shutil.rmtree(self.repo_dir)
-        # Capture the output of the unzip command to verify the directory was created
-        unzip_output = utils.exec_cmd(
+        utils.exec_cmd(
             "unzip master.zip", sudo_user=self.user, cwd=self.home_dir)
-
-        # I'm not quite sure about what to do here. It seems the zip-file is sometimes not available
-        # without me being able to tell why.
-        if "creating: {}/automx-master/".format(self.home_dir) not in unzip_output:
-            raise Exception("Failed to extract automx-master directory from master.zip")
-
-        # Proceed with the installation
         utils.exec_cmd(
             "{} setup.py install".format(
                 python.get_path("python", self.venv_path)),

--- a/modoboa_installer/scripts/automx.py
+++ b/modoboa_installer/scripts/automx.py
@@ -76,8 +76,16 @@ class Automx(base.Installer):
         self.repo_dir = "{}/automx-master".format(self.home_dir)
         if os.path.exists(self.repo_dir):
             shutil.rmtree(self.repo_dir)
-        utils.exec_cmd(
+        # Capture the output of the unzip command to verify the directory was created
+        unzip_output = utils.exec_cmd(
             "unzip master.zip", sudo_user=self.user, cwd=self.home_dir)
+
+        # I'm not quite sure about what to do here. It seems the zip-file is sometimes not available
+        # without me being able to tell why.
+        if "creating: {}/automx-master/".format(self.home_dir) not in unzip_output:
+            raise Exception("Failed to extract automx-master directory from master.zip")
+
+        # Proceed with the installation
         utils.exec_cmd(
             "{} setup.py install".format(
                 python.get_path("python", self.venv_path)),

--- a/modoboa_installer/scripts/postwhite.py
+++ b/modoboa_installer/scripts/postwhite.py
@@ -87,6 +87,5 @@ class Postwhite(base.Installer):
             utils.copy_file(postwhite_backup_configuration, self.config_dir)
             utils.success("postwhite.conf restored from backup")
 
-
     def download_file(self, url, destination):
         urllib.request.urlretrieve(url, destination)

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -503,7 +503,7 @@ def download_remote_file(path_to_remote_file: str, target: str, retries: int = 5
 
     for attempt in range(retries):
         try:
-            exec_cmd(f"wget {path_to_remote_file}")
+            exec_cmd(f"wget {path_to_remote_file} -O {target}")
             return os.path.abspath(target)
         except:
             if attempt < retries - 1:  # Only log the error if this was not the last attempt

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -504,7 +504,7 @@ def download_remote_file(path_to_remote_file: str, target: str, retries: int = 5
     for attempt in range(retries):
         try:
             exec_cmd(f"wget {path_to_remote_file}")
-            return target  # Return the path of the downloaded file if the download succeeds
+            return os.path.abspath(target)
         except:
             if attempt < retries - 1:  # Only log the error if this was not the last attempt
                 warning(f"Failed to download {path_to_remote_file}, retrying... ({attempt + 1}/{retries})")

--- a/modoboa_installer/utils.py
+++ b/modoboa_installer/utils.py
@@ -235,6 +235,16 @@ def success(message):
     printcolor(message, GREEN)
 
 
+def info(message):
+    """Print info message."""
+    printcolor(message, BLUE)
+
+
+def warning(message):
+    """Print info message."""
+    printcolor(message, YELLOW)
+
+
 def convert_version_to_int(version):
     """Convert a version string to an integer."""
     number_bits = (8, 8, 16)
@@ -474,3 +484,30 @@ def validate_backup_path(path: str, silent_mode: bool):
         mkdir_safe(os.path.join(backup_path, dir),
                    stat.S_IRWXU | stat.S_IRWXG, pw[2], pw[3])
     return backup_path
+
+
+def download_remote_file(path_to_remote_file: str, target: str, retries: int = 5):
+    """Downloads a file from a remote server with the specified number of retries.
+
+    Args:
+        path_to_remote_file (str): The URL of the file to download.
+        target (str): The path where to put the file
+        retries (int): The number of times to retry the download if it fails.
+
+    Returns:
+        str: The local path of the downloaded file.
+    """
+
+    # Ensure the directory exists, create it if it doesn't
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+
+    for attempt in range(retries):
+        try:
+            exec_cmd(f"wget {path_to_remote_file}")
+            return target  # Return the path of the downloaded file if the download succeeds
+        except:
+            if attempt < retries - 1:  # Only log the error if this was not the last attempt
+                warning(f"Failed to download {path_to_remote_file}, retrying... ({attempt + 1}/{retries})")
+            else:
+                raise  # Re-raise the last exception if all retries fail
+    return target  # This line will not be reached due to the raise statement above


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The `_setup_venv` method in the existing codebase has been experiencing intermittent SSL connection issues when attempting to download a file using `wget`. This problem has been causing the method to fail occasionally, preventing the successful setup of a virtual environment. Additionally, the method assumes the downloaded archive will be located in a certain directory without verifying the file's existence, leading to potential errors during the unzipping process.

Current behavior before PR:
1. The `_setup_venv` method uses `wget` to download a file, but if an SSL connection issue occurs, the method fails without retrying the download.
2. The method assumes the downloaded file will be located in a specific directory and proceeds to attempt unzipping the file without verifying its existence, which could lead to a failure if the file is not found.

Desired behavior after PR is merged:
1. A new method `download_remote_file` has been introduced to handle file downloads, with the capability to retry the download a specified number of times in case of failures, mitigating the impact of intermittent SSL connection issues.
2. The `_setup_venv` method now utilizes the `download_remote_file` method to handle the file download, ensuring that the file exists before proceeding to unzip it.
3. The `download_remote_file` method ensures the target directory exists or creates it if necessary, and returns the absolute path of the downloaded file, providing more robust file handling and aiding in troubleshooting if issues arise in the future.
