### PR TITLE
Update master.cf.tpl - add missing headers

### DIFF
--- a/modoboa_installer/scripts/files/postfix/master.cf.tpl
+++ b/modoboa_installer/scripts/files/postfix/master.cf.tpl
@@ -149,4 +149,4 @@ autoreply unix        -       n       n       -       -       pipe
 %{amavis_enabled}        -o smtpd_client_connection_count_limit=0 
 %{amavis_enabled}        -o smtpd_client_connection_rate_limit=0 
 %{amavis_enabled}        -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks
-%{amavis_enabled}        -o local_header_rewrite_clients=
+%{amavis_enabled}        -o local_header_rewrite_clients=permit_mynetworks,permit_sasl_authenticated


### PR DESCRIPTION
Add missing headers for mail from sasl auth'd users and mynetworks.

Description of the issue/feature this PR addresses:
In our environment we've got quite a number of scanners/MFC printers (and some other devices) that send mail but don't supply normal RFC required headers - namely date.
Tweaking the master.cf fixes this in a way that I don't think would adversely impact anyone.

Current behavior before PR:
Missing headers, like date would cause the file to show up in quarantined list for amavis (though I don't think any in our case actually got quarantined - though I'm not positive.)

Desired behavior after PR is merged:
This simply adds missing header fields required by RFC, though only for clients who have done sasl or are part of my-networks, so this should be safe from breaking DKIM etc. (And shouldn't allow abuse from non-priv'd clients/senders.)
