### PR TITLE
Fixed frozen apt install during Modoboa upgrade when package already installed with old config file

### DIFF
--- a/modoboa_installer/package.py
+++ b/modoboa_installer/package.py
@@ -57,12 +57,12 @@ class DEBPackage(Package):
     def install(self, name):
         """Install a package."""
         self.update()
-        utils.exec_cmd("apt-get -o Dpkg::Progress-Fancy=0 install --quiet --assume-yes {}".format(name))
+        utils.exec_cmd("apt-get -o Dpkg::Progress-Fancy=0 install --quiet --assume-yes -o DPkg::options::=--force-confold {}".format(name))
 
     def install_many(self, names):
         """Install many packages."""
         self.update()
-        return utils.exec_cmd("apt-get -o Dpkg::Progress-Fancy=0 install --quiet --assume-yes {}".format(
+        return utils.exec_cmd("apt-get -o Dpkg::Progress-Fancy=0 install --quiet --assume-yes -o DPkg::options::=--force-confold {}".format(
             " ".join(names)))
 
     def get_installed_version(self, name):


### PR DESCRIPTION
Fixes apt-get install when package already exists with an old config file. The updated code automatically installs the package-maintainer's version of any config files that come with the package.

Resolves issue [ Upgrade freezes while installing nginx #538 ](https://github.com/modoboa/modoboa-installer/issues/538)

# Steps to reproduce
`./run.py --upgrade <your domain>`
**Before**
![image](https://github.com/modoboa/modoboa-installer/assets/28704571/6a01c94a-85c5-425b-885e-32488450884f)

**This is the reason**
![image](https://github.com/modoboa/modoboa-installer/assets/28704571/5ee3b557-0b43-42ab-bd25-260e13c5a3de)
![image](https://github.com/modoboa/modoboa-installer/assets/28704571/021c90d6-4043-403e-a3e5-d133f9419a0d)

**After my patch**
**I restored the VM to the point prior to the attempted upgrade.**
**Re-attempt the upgrade.**
**nginx installs successfully!**
![image](https://github.com/modoboa/modoboa-installer/assets/28704571/95d4d2d4-1425-45d0-a5ac-86b45108f4cf)
