### PR TITLE
LMDE compatability

### DIFF
--- a/modoboa_installer/package.py
+++ b/modoboa_installer/package.py
@@ -108,7 +108,7 @@ def get_backend():
     """Return the appropriate package backend."""
     distname = utils.dist_name()
     backend = None
-    if distname in ["debian", "debian gnu/linux", "ubuntu", "linuxmint", "LMDE"]:
+    if distname in ["debian", "debian gnu/linux", "ubuntu", "linuxmint"]:
         backend = DEBPackage
     elif "centos" in distname:
         backend = RPMPackage

--- a/modoboa_installer/package.py
+++ b/modoboa_installer/package.py
@@ -108,7 +108,7 @@ def get_backend():
     """Return the appropriate package backend."""
     distname = utils.dist_name()
     backend = None
-    if distname in ["debian", "debian gnu/linux", "ubuntu"]:
+    if distname in ["debian", "debian gnu/linux", "ubuntu", "linuxmint", "LMDE"]:
         backend = DEBPackage
     elif "centos" in distname:
         backend = RPMPackage


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes installer compatibility errors with LMDE by adding "linuxmint" to the list of Debian distros.

Current behavior before PR:
Fails to install on LMDE

Desired behavior after PR is merged:
Installs on LMDE

Note: Although this fixes the issue for LMDE, the true way to fix this for _all_ Debian derivatives is to implement the "ID_LIKE" parameter from /etc/os-release. 

Note 2: This fix has _not_ been tested on ubuntu or base debian.