### PR TITLE
Support for kali linux + fixing amavis dependency issue

### DIFF
--- a/modoboa_installer/package.py
+++ b/modoboa_installer/package.py
@@ -108,7 +108,7 @@ def get_backend():
     """Return the appropriate package backend."""
     distname = utils.dist_name()
     backend = None
-    if distname in ["debian", "debian gnu/linux", "ubuntu", "linuxmint"]:
+    if distname in ["debian", "debian gnu/linux", "ubuntu", "linuxmint", "kali gnu/linux",]:
         backend = DEBPackage
     elif "centos" in distname:
         backend = RPMPackage

--- a/modoboa_installer/scripts/amavis.py
+++ b/modoboa_installer/scripts/amavis.py
@@ -17,7 +17,7 @@ class Amavis(base.Installer):
     packages = {
         "deb": [
             "libdbi-perl", "amavisd-new", "arc", "arj", "cabextract",
-            "liblz4-tool", "lrzip", "lzop", "p7zip-full", "rpm2cpio",
+            "lz4", "lrzip", "lzop", "p7zip-full", "rpm2cpio",
             "unrar-free",
         ],
         "rpm": [


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- kali linux is not supported
- installation fails because of a wrong amavis dependency in the list

Current behavior before PR:
 Installation now supports kali linux and does not error with amavis dependency issue
Desired behavior after PR is merged:
 Installation finishes OK and I can drink coffee instead of babysitting it