### PR TITLE
Fix #561 and #576

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -103,7 +103,7 @@ class PostgreSQL(Database):
     def create_database(self, name, owner):
         """Create a database."""
         code, output = utils.exec_cmd(
-            "psql -lqt | cut -d \| -f 1 | grep -w {} | wc -l"
+            "psql -lqt | cut -d \\| -f 1 | grep -w {} | wc -l"
             .format(name), sudo_user=self.dbuser)
         if code:
             return

--- a/modoboa_installer/scripts/modoboa.py
+++ b/modoboa_installer/scripts/modoboa.py
@@ -101,8 +101,8 @@ class Modoboa(base.Installer):
                     req_version = matrix[extension]
                     if req_version is None:
                         continue
-                    req_version = req_version.replace("<", "\<")
-                    req_version = req_version.replace(">", "\>")
+                    req_version = req_version.replace("<", "\\<")
+                    req_version = req_version.replace(">", "\\>")
                     packages.append("{}{}".format(extension, req_version))
                 else:
                     packages.append(extension)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

#561 and #576

Current behavior before PR:

Issued warnings:
```
/root/modoboa-installer/modoboa_installer/database.py:106: SyntaxWarning: invalid escape sequence '\|'
  "psql -lqt | cut -d \| -f 1 | grep -w {} | wc -l"
/root/modoboa-installer/modoboa_installer/scripts/modoboa.py:104: SyntaxWarning: invalid escape sequence '\<'
  req_version = req_version.replace("<", "\<")
/root/modoboa-installer/modoboa_installer/scripts/modoboa.py:105: SyntaxWarning: invalid escape sequence '\>'
  req_version = req_version.replace(">", "\>")
```

Desired behavior after PR is merged:

No warnings.