### PR TITLE
Use extras instead of requirements file

### DIFF
--- a/modoboa_installer/python.py
+++ b/modoboa_installer/python.py
@@ -89,16 +89,6 @@ def install_package_from_repository(name, url, vcs="git", venv=None, **kwargs):
     utils.exec_cmd(cmd, **kwargs)
 
 
-def install_package_from_remote_requirements(url, venv=None, **kwargs):
-    """Install a Python package from a file."""
-    cmd = "{} install {} {}".format(
-        get_pip_path(venv),
-        "-r",
-        url
-    )
-    utils.exec_cmd(cmd, **kwargs)
-
-
 def setup_virtualenv(path, sudo_user=None):
     """Install a virtualenv if needed."""
     if os.path.exists(path):


### PR DESCRIPTION
Align with the new packaging system of modoboa and get rid of the need to download requirements file by using extras directly.