### PR TITLE
Update MySQL (MariaDB) install to account for Ubuntu 24.04.

### DIFF
--- a/modoboa_installer/database.py
+++ b/modoboa_installer/database.py
@@ -184,7 +184,7 @@ class MySQL(Database):
                 self.packages["deb"].append("libmariadbclient-dev")
         elif name == "ubuntu":
             if version.startswith("2"):
-                # Works for Ubuntu 22 and 20
+                # Works for Ubuntu 20, 22, and 24.
                 self.packages["deb"].append("libmariadb-dev")
             else:
                 self.packages["deb"].append("libmysqlclient-dev")
@@ -201,7 +201,7 @@ class MySQL(Database):
                 return
         if (
             (name.startswith("debian") and (version.startswith("11") or version.startswith("12"))) or
-            (name.startswith("ubuntu") and version.startswith("22"))
+            (name.startswith("ubuntu") and int(version[:2]) >= 22)
         ):
             queries = [
                 "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('{}')"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Broken installation of Modoboa on Ubuntu 24.04 with MySQL as documented in: https://github.com/modoboa/modoboa-installer/issues/591

**Current behavior before PR:**
Modoboa installation is unusable due to database related issues when installed on Ubuntu 24.04 and using MySQL.

**Desired behavior after PR is merged:**
Modoboa works correctly after running the installer on Ubuntu 24.04 with MySQL as the database.
