### PR TITLE
Add missing dependancy on unzip for postwhite.

### DIFF
--- a/modoboa_installer/scripts/postwhite.py
+++ b/modoboa_installer/scripts/postwhite.py
@@ -20,8 +20,8 @@ class Postwhite(base.Installer):
     ]
     no_daemon = True
     packages = {
-        "deb": ["bind9-host"],
-        "rpm": ["bind-utils"]
+        "deb": ["bind9-host", "unzip"],
+        "rpm": ["bind-utils", "unzip"]
     }
 
     def install_from_archive(self, repository, target_dir):


### PR DESCRIPTION
When installing modoboa with installer but without certain parts (automx, rspamd) the unzip package is never installed.
On a blank system, unzip is not present and installer fails

Current behavior before PR:
```
-2025-09-22 04:14:47--  https://codeload.github.com/spf-tools/spf-tools/zip/refs/heads/master
Resolving codeload.github.com (codeload.github.com)... 140.82.121.10
Connecting to codeload.github.com (codeload.github.com)|140.82.121.10|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/zip]
Saving to: ‘master.zip’

     0K .......... .......... .......... .......... .......... 3.48M
    50K .....                                                  17.9M=0.01s

2025-09-22 04:14:47 (3.78 MB/s) - ‘master.zip’ saved [56740]

/bin/sh: 1: unzip: not found
mv: cannot stat 'spf-tools-master': No such file or directory
--2025-09-22 04:14:47--  https://github.com/stevejenkins/postwhite/archive/master.zip
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/stevejenkins/postwhite/zip/refs/heads/master [following]
--2025-09-22 04:14:47--  https://codeload.github.com/stevejenkins/postwhite/zip/refs/heads/master
Resolving codeload.github.com (codeload.github.com)... 140.82.121.9
Connecting to codeload.github.com (codeload.github.com)|140.82.121.9|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/zip]
Saving to: ‘master.zip’

     0K .......... .......... .......... .......... .......... 3.61M
    50K ...                                                    16.7M=0.01s

2025-09-22 04:14:48 (3.79 MB/s) - ‘master.zip’ saved [54510]

/bin/sh: 1: unzip: not found
mv: cannot stat 'postwhite-master': No such file or directory
```


Desired behavior after PR is merged: installation completes.