### PR TITLE
Fix amavis installation on Debian 13 (LZ4)

### DIFF
--- a/modoboa_installer/scripts/amavis.py
+++ b/modoboa_installer/scripts/amavis.py
@@ -52,7 +52,17 @@ class Amavis(base.Installer):
         packages = super(Amavis, self).get_packages()
         if package.backend.FORMAT == "deb":
             db_driver = "pg" if self.db_driver == "pgsql" else self.db_driver
-            return packages + ["libdbd-{}-perl".format(db_driver)]
+            packages += ["libdbd-{}-perl".format(db_driver)]
+
+            name, version = utils.dist_info()
+            try:
+                major_version = int(version.split(".")[0])
+            except ValueError:
+                major_version = 0
+            if major_version >= 13:
+                packages = [p if p != "liblz4-tool" else "lz4" for p in packages]
+            return packages
+        
         if self.db_driver == "pgsql":
             db_driver = "Pg"
         elif self.db_driver == "mysql":


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This PR fixes a bug when installing amavis, since the liblz4-tool package was renamed starting with Debian 13.

### Current behavior before PR:
```
Installing amavis
Reading package lists...
Building dependency tree...
Reading state information...
postgresql is already the newest version (17+278).
postgresql-server-dev-all is already the newest version (278).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Synchronizing state of postgresql.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable postgresql
● postgresql.service - PostgreSQL RDBMS
     Loaded: loaded (/usr/lib/systemd/system/postgresql.service; enabled; preset: enabled)
     Active: active (exited) since Tue 2025-09-23 05:16:16 UTC; 16s ago
 Invocation: 124e4d33161649ba9826ecaf9ce2ac8b
   Main PID: 185604 (code=exited, status=0/SUCCESS)
   Mem peak: 1.7M
        CPU: 8ms

Sep 23 05:16:16 mail systemd[1]: Starting postgresql.service - PostgreSQL RDBMS...
Sep 23 05:16:16 mail systemd[1]: Finished postgresql.service - PostgreSQL RDBMS.
Reading package lists...
Building dependency tree...
Reading state information...
Package liblz4-tool is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'liblz4-tool' has no installation candidate
Failed to install dependencies
```


### Desired behavior after PR is merged:
Installation completes.
