### PR TITLE
Change restore target to use storage_dir config

### DIFF
--- a/modoboa_installer/scripts/radicale.py
+++ b/modoboa_installer/scripts/radicale.py
@@ -82,7 +82,9 @@ class Radicale(base.Installer):
         radicale_backup = os.path.join(
             self.archive_path, "custom/radicale")
         if os.path.isdir(radicale_backup):
-            restore_target = os.path.join(self.home_dir, "collections")
+            # Use storage_dir for data, fallback to home_dir for compatibility
+            storage_dir = self.config.get("radicale", "storage_dir", fallback=self.home_dir)
+            restore_target = os.path.join(storage_dir, "collections")
             if os.path.isdir(restore_target):
                 shutil.rmtree(restore_target)
             shutil.copytree(radicale_backup, restore_target)


### PR DESCRIPTION
Updated the restore target directory to use storage_dir for data, allowing the user to configure where the data should be stored.
