### PR TITLE
ClamAV + rspamd wrong server / socket

### DIFF
--- a/modoboa_installer/scripts/files/rspamd/local.d/antivirus.conf.tpl
+++ b/modoboa_installer/scripts/files/rspamd/local.d/antivirus.conf.tpl
@@ -1,12 +1,15 @@
 clamav {
+  action = reject;
+  message = '${SCANNER}: virus found: "${VIRUS}"';
   scan_mime_parts = true;
   scan_text_mime = true;
   scan_image_mime = true;
   retransmits = 2;
   timeout = 30;
   symbol = "CLAM_VIRUS";
+  symbol_fail = "CLAM_VIRUS_FAIL";
   type = "clamav";
-  servers = "127.0.0.1:3310"
+  servers = "/run/clamav/clamd.ctl"
   patterns {
     # symbol_name = "pattern";
     JUST_EICAR = "Test.EICAR";


### PR DESCRIPTION
I have multiple instances of Modoboa running with the latest being V 2.7.2.

I noticed under https://host.domain.tld/rspamd/#history that i get the error ```clamav: failed to scan, maximum retransmits exceed```. After some digging I found that in https://github.com/pionsys-mhs/modoboa-installer/blob/master/modoboa_installer/scripts/files/rspamd/local.d/antivirus.conf.tpl#L9 the connection to ClamAV is done via a TCP socket on port 3310.
I checked all my installations and none of them had an open port on 3310.

https://docs.clamav.net/manual/Usage/Scanning.html#daemon says that ClamAV is listening on the socket defined in `/etc/clamav/clamd.conf`. This file, `Automatically Generated by clamav-daemon postinst` shows `LocalSocket /var/run/clamav/clamd.ctl`.

I changed https://github.com/pionsys-mhs/modoboa-installer/blob/master/modoboa_installer/scripts/files/rspamd/local.d/antivirus.conf.tpl#L9 to `server="/run/clamav/clamd.ctl"` and the error was gone.

During my tests with the EICAR Test File, i noticed that mail that have the test file attached to it are still sent out. Looking at the rspamd history i saw that the weight of WHITELIST_AUTHENTICATED reduced the rspamd score to a point where the message is not considered "spam" anymore and that no action was taken before sending the message with the EICAR test file.

Increasing the weight of CLAM_VIRUS marked the message as "spam" and prevented the mail client form sending it, but this is no the correct classification.

Therefore I added the line following lines:
```
  action = reject;
  message = '${SCANNER}: virus found: "${VIRUS}"';
  symbol_fail = "CLAM_VIRUS_FAIL";
```

With these additional lines the email is correctly being classified as containing a virus based on rspamd's "pass-through module" = clamav, and not sent in the first place.

Tested on multiple servers with the EICAR test file downloaded from https://secure.eicar.org/eicar.com.txt.