### PR TITLE
Passwort Reset Link is not Working

### DIFF
--- a/modoboa_installer/scripts/files/nginx/modoboa.conf.tpl
+++ b/modoboa_installer/scripts/files/nginx/modoboa.conf.tpl
@@ -44,7 +44,7 @@ server {
 %{rspamd_enabled}        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 %{rspamd_enabled}    }
 
-    location ~ ^/(api|accounts|autodiscover) {
+    location ~ ^/(api|accounts|autodiscover|reset) {
         include uwsgi_params;
         uwsgi_param UWSGI_SCRIPT instance.wsgi:application;
         uwsgi_pass modoboa;


### PR DESCRIPTION
With the password reset link, e.g. `https://mail.example.com/reset/Mg/token/` sent to the secondary email address, it is always being redirected to the login page therefore making it impossible to change the password.

This PR fixes the nginx template to properly include the reset endpoint and therefore making it possible to actually get to the `Change password` site.
<img width="1424" height="378" alt="image" src="https://github.com/user-attachments/assets/5c114c41-5b30-4224-800f-27e973c7d6b5" />
