### PR TITLE
Spoofed E-Mails are being being received despite DMARC Policy set to Reject

### DIFF
--- a/modoboa_installer/scripts/files/rspamd/local.d/dmarc.conf.tpl
+++ b/modoboa_installer/scripts/files/rspamd/local.d/dmarc.conf.tpl
@@ -1,3 +1,9 @@
+actions {
+  reject = "reject";
+  quarantine = "add header";
+  softfail = "no action";
+}
+
 reporting {
   # Required attributes
   enabled = true; # Enable reports in general


### PR DESCRIPTION
With the current rspamd configuration it is possible to receive spoofed emails even though the DMARC policy is set to `reject`.

This PR fixes this error by adding the forced actions from the rspamd documentation (https://docs.rspamd.com/modules/dmarc/#forcing-actions) to the template of the installer.

With this, a failed DMARC check will
- reject a mail via forced actions if the DMARC policy is set to `reject`
- add the SPAM header via forced actions if the DMARC policy is set to `quarantine`

It might also be worth to consider increasing the weights of the following rspamd symbols:
- VIOLATED_DIRECT_SPF (composite): 3.50
- DMARC_POLICY_REJECT (dmarc): 2.00
- DMARC_POLICY_REJECT (policies): 2.00
- R_SPF_FAIL (spf): 1.00
- R_SPF_FAIL (policies): 1.00